### PR TITLE
refactor: move apply logic outside the services

### DIFF
--- a/pkg/rpdac/dashboard_test.go
+++ b/pkg/rpdac/dashboard_test.go
@@ -198,9 +198,9 @@ func TestGetDashboard(t *testing.T) {
 		Widget:          mockWidget,
 		ProjectSettings: mockProjectSettings})
 
-	got, err := r.Dashboard.GetDashboard("test_project", 1)
+	got, err := r.Dashboard.Get("test_project", 1)
 	if err != nil {
-		t.Errorf("ReportPortal.GetDashboard returned error: %v", err)
+		t.Errorf("ReportPortal.Get returned error: %v", err)
 	}
 
 	want := &Dashboard{
@@ -458,9 +458,9 @@ func TestGetDashboardByName(t *testing.T) {
 		Widget:          mockWidget,
 		ProjectSettings: mockProjectSettings})
 
-	got, err := r.Dashboard.GetDashboardByName("test_project", "MK E2E Tests Overview")
+	got, err := r.Dashboard.GetByName("test_project", "MK E2E Tests Overview")
 	if err != nil {
-		t.Errorf("ReportPortal.GetDashboardByName returned error: %v", err)
+		t.Errorf("ReportPortal.GetByName returned error: %v", err)
 	}
 
 	want := &Dashboard{
@@ -541,9 +541,9 @@ func TestGetDashboardByName_NotFound(t *testing.T) {
 
 	r := NewReportPortal(&reportportal.Client{Dashboard: mockDashboard})
 
-	got, err := r.Dashboard.GetDashboardByName("test_project", "MK E2E Tests Overview")
+	got, err := r.Dashboard.GetByName("test_project", "MK E2E Tests Overview")
 	if err != nil {
-		t.Errorf("ReportPortal.GetDashboardByName returned error: %v", err)
+		t.Errorf("ReportPortal.GetByName returned error: %v", err)
 	}
 
 	if got != nil {
@@ -563,9 +563,9 @@ func TestGetDashboardByName_Error(t *testing.T) {
 
 	r := NewReportPortal(&reportportal.Client{Dashboard: mockDashboard})
 
-	_, err := r.Dashboard.GetDashboardByName("test_project", "MK E2E Tests Overview")
+	_, err := r.Dashboard.GetByName("test_project", "MK E2E Tests Overview")
 	if err == nil {
-		t.Errorf("ReportPortal.GetDashboardByName did not return the error")
+		t.Errorf("ReportPortal.GetByName did not return the error")
 	}
 }
 
@@ -807,9 +807,9 @@ func TestCreateDashboard(t *testing.T) {
 		},
 	}
 
-	err := r.Dashboard.CreateDashboard("test_project", inputDashboard)
+	err := r.Dashboard.Create("test_project", inputDashboard)
 	if err != nil {
-		t.Errorf("ReportPortal.CreateDashboard returned error: %v", err)
+		t.Errorf("ReportPortal.Create returned error: %v", err)
 	}
 
 	testDeepEqual(t, mockDashboard.Counter, reportportal.MockDashboardServiceCounter{Create: 1, AddWidget: 2})
@@ -900,7 +900,7 @@ func TestApplyDashboard_Create(t *testing.T) {
 		},
 	}
 
-	err := r.Dashboard.ApplyDashboard("test_project", inputDashboard)
+	err := r.ApplyObject("test_project", inputDashboard)
 	if err != nil {
 		t.Errorf("ReportPortal.ApplyDashboard returned error: %v", err)
 	}
@@ -1082,7 +1082,7 @@ func TestApplyDashboard_Update(t *testing.T) {
 		},
 	}
 
-	err := r.Dashboard.ApplyDashboard("test_project", inputDashboard)
+	err := r.ApplyObject("test_project", inputDashboard)
 	if err != nil {
 		t.Errorf("ReportPortal.ApplyDashboard returned error: %v", err)
 	}
@@ -1313,7 +1313,7 @@ func TestApplyDashboard_Skip(t *testing.T) {
 		},
 	}
 
-	err := r.Dashboard.ApplyDashboard("test_project", inputDashboard)
+	err := r.ApplyObject("test_project", inputDashboard)
 	if err != nil {
 		t.Errorf("ReportPortal.ApplyDashboard returned error: %v", err)
 	}
@@ -1363,7 +1363,7 @@ func TestDeleteDashboard(t *testing.T) {
 		Dashboard: mockDashboard,
 	})
 
-	err := r.Dashboard.DeleteDashboard("test_project", "MK E2E Tests Overview")
+	err := r.Dashboard.Delete("test_project", "MK E2E Tests Overview")
 	if err != nil {
 		t.Errorf("ReportPortal.DeleteDashboard returned error: %v", err)
 	}

--- a/pkg/rpdac/filter_test.go
+++ b/pkg/rpdac/filter_test.go
@@ -47,7 +47,7 @@ func TestGetFilter(t *testing.T) {
 		Filter: mockFilter,
 	})
 
-	got, err := r.Filter.GetFilter("test_project", 2)
+	got, err := r.Filter.Get("test_project", 2)
 	if err != nil {
 		t.Errorf("ReportPortal.GetFilter returned error: %v", err)
 	}
@@ -109,7 +109,7 @@ func TestGetFilterByName(t *testing.T) {
 		Filter: mockFilter,
 	})
 
-	got, err := r.Filter.GetFilterByName("test_project", "mk-e2e-test-suite")
+	got, err := r.Filter.GetByName("test_project", "mk-e2e-test-suite")
 	if err != nil {
 		t.Errorf("ReportPortal.GetFilterByName returned error: %v", err)
 	}
@@ -146,7 +146,7 @@ func TestGetFilterByName_NotFound(t *testing.T) {
 		Filter: mockFilter,
 	})
 
-	got, err := r.Filter.GetFilterByName("test_project", "mk-e2e-test-suite")
+	got, err := r.Filter.GetByName("test_project", "mk-e2e-test-suite")
 	if err != nil {
 		t.Errorf("ReportPortal.GetFilterByName returned error: %v", err)
 	}
@@ -170,7 +170,7 @@ func TestGetFilterByName_Error(t *testing.T) {
 		Filter: mockFilter,
 	})
 
-	_, err := r.Filter.GetFilterByName("test_project", "mk-e2e-test-suite")
+	_, err := r.Filter.GetByName("test_project", "mk-e2e-test-suite")
 	if err == nil {
 		t.Errorf("ReportPortal.GetFilterByName did not return the error")
 	}
@@ -238,7 +238,7 @@ func TestCreateFilter(t *testing.T) {
 		},
 	}
 
-	err := r.Filter.CreateFilter("test_project", inputFilter)
+	err := r.Filter.Create("test_project", inputFilter)
 	if err != nil {
 		t.Errorf("ReportPortal.CreateFilter returned error: %v", err)
 	}
@@ -313,7 +313,7 @@ func TestApplyFilter_Create(t *testing.T) {
 		},
 	}
 
-	err := r.Filter.ApplyFilter("test_project", inputFilter)
+	err := r.ApplyObject("test_project", inputFilter)
 	if err != nil {
 		t.Errorf("ReportPortal.ApplyFilter returned error: %v", err)
 	}
@@ -411,7 +411,7 @@ func TestApplyFilter_Update(t *testing.T) {
 		},
 	}
 
-	err := r.Filter.ApplyFilter("test_project", inputFilter)
+	err := r.ApplyObject("test_project", inputFilter)
 	if err != nil {
 		t.Errorf("ReportPortal.ApplyFilter returned error: %v", err)
 	}
@@ -480,7 +480,7 @@ func TestApplyFilter_Skip(t *testing.T) {
 		},
 	}
 
-	err := r.Filter.ApplyFilter("test_project", inputFilter)
+	err := r.ApplyObject("test_project", inputFilter)
 	if err != nil {
 		t.Errorf("ReportPortal.ApplyFilter returned error: %v", err)
 	}

--- a/pkg/rpdac/moks.go
+++ b/pkg/rpdac/moks.go
@@ -1,91 +1,62 @@
 package rpdac
 
-type MockDashboardServiceCounter struct {
-	GetDashboard       int
-	GetDashboardByName int
-	CreateDashboard    int
-	ApplyDashboard     int
-	DeleteDashboard    int
+type MockServiceCounter struct {
+	Get       int
+	GetByName int
+	Create    int
+	Update    int
+	Delete    int
 }
 
-type MockDashboardService struct {
-	GetDashboardM       func(project string, id int) (*Dashboard, error)
-	GetDashboardByNameM func(project, name string) (*Dashboard, error)
-	CreateDashboardM    func(project string, d *Dashboard) error
-	ApplyDashboardM     func(project string, d *Dashboard) error
-	DeleteDashboardM    func(project, name string) error
+type MockService struct {
+	GetM       func(project string, id int) (Object, error)
+	GetByNameM func(project, name string) (Object, error)
+	CreateM    func(project string, o Object) error
+	UpdateM    func(project string, current Object, target Object) error
+	DeleteM    func(project, name string) error
 
-	Counter MockDashboardServiceCounter
-}
-
-func (s *MockDashboardService) Get(project string, id int) (Object, error) {
-	return s.GetDashboard(project, id)
-}
-func (s *MockDashboardService) Create(project string, o Object) error {
-	return s.CreateDashboard(project, o.(*Dashboard))
-}
-func (s *MockDashboardService) Apply(project string, o Object) error {
-	return s.ApplyDashboard(project, o.(*Dashboard))
-}
-func (s *MockDashboardService) GetDashboard(project string, id int) (*Dashboard, error) {
-	s.Counter.GetDashboard++
-	return s.GetDashboardM(project, id)
-}
-func (s *MockDashboardService) GetDashboardByName(project, name string) (*Dashboard, error) {
-	s.Counter.GetDashboardByName++
-	return s.GetDashboardByNameM(project, name)
-}
-func (s *MockDashboardService) CreateDashboard(project string, d *Dashboard) error {
-	s.Counter.CreateDashboard++
-	return s.CreateDashboardM(project, d)
-}
-func (s *MockDashboardService) ApplyDashboard(project string, d *Dashboard) error {
-	s.Counter.ApplyDashboard++
-	return s.ApplyDashboardM(project, d)
-}
-func (s *MockDashboardService) DeleteDashboard(project, name string) error {
-	s.Counter.DeleteDashboard++
-	return s.DeleteDashboardM(project, name)
+	Counter MockServiceCounter
 }
 
-type MockFilterServiceCounter struct {
-	GetFilter       int
-	GetFilterByName int
-	CreateFilter    int
-	ApplyFilter     int
+func (s *MockService) Get(project string, id int) (Object, error) {
+	s.Counter.Get++
+	return s.GetM(project, id)
+}
+func (s *MockService) GetByName(project, name string) (Object, error) {
+	s.Counter.GetByName++
+	return s.GetByNameM(project, name)
+}
+func (s *MockService) Create(project string, o Object) error {
+	s.Counter.Create++
+	return s.CreateM(project, o)
+}
+func (s *MockService) Update(project string, current Object, target Object) error {
+	s.Counter.Update++
+	return s.UpdateM(project, current, target)
+}
+func (s *MockService) Delete(project, name string) error {
+	s.Counter.Delete++
+	return s.DeleteM(project, name)
 }
 
-type MockFilterService struct {
-	GetFilterM       func(project string, id int) (*Filter, error)
-	GetFilterByNameM func(project, name string) (*Filter, error)
-	CreateFilterM    func(project string, f *Filter) error
-	ApplyFilterM     func(project string, f *Filter) error
-
-	Counter MockFilterServiceCounter
+type MockObjectCounter struct {
+	Equals int
 }
 
-func (s *MockFilterService) Get(project string, id int) (Object, error) {
-	return s.GetFilter(project, id)
+type MockObject struct {
+	Kind ObjectKind
+	Name string
+
+	Counter MockObjectCounter
 }
-func (s *MockFilterService) Create(project string, o Object) error {
-	return s.CreateFilter(project, o.(*Filter))
+
+func (m *MockObject) GetKind() ObjectKind {
+	return m.Kind
 }
-func (s *MockFilterService) Apply(project string, o Object) error {
-	return s.ApplyFilter(project, o.(*Filter))
+func (m *MockObject) GetName() string {
+	return m.Name
 }
-func (s *MockFilterService) GetFilter(project string, id int) (*Filter, error) {
-	s.Counter.GetFilter++
-	return s.GetFilterM(project, id)
-}
-func (s *MockFilterService) GetFilterByName(project, name string) (*Filter, error) {
-	s.Counter.GetFilterByName++
-	return s.GetFilterByNameM(project, name)
-}
-func (s *MockFilterService) CreateFilter(project string, f *Filter) error {
-	s.Counter.CreateFilter++
-	return s.CreateFilterM(project, f)
-}
-func (s *MockFilterService) ApplyFilter(project string, f *Filter) error {
-	s.Counter.ApplyFilter++
-	return s.ApplyFilterM(project, f)
+func (m *MockObject) Equals(o Object) bool {
+	m.Counter.Equals++
+	return m.GetKind() == o.GetKind() && m.GetName() == o.GetName()
 }

--- a/pkg/rpdac/reportportal_test.go
+++ b/pkg/rpdac/reportportal_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 type Tesso struct {
@@ -80,8 +81,8 @@ func TestExport_Dashboard(t *testing.T) {
 
 	r := NewReportPortal(nil)
 
-	r.Dashboard = &MockDashboardService{
-		GetDashboardM: func(project string, id int) (*Dashboard, error) {
+	r.Dashboard = &MockService{
+		GetM: func(project string, id int) (Object, error) {
 			testEqual(t, project, "test_project")
 			testEqual(t, id, 3)
 			return &Dashboard{
@@ -112,8 +113,8 @@ func TestExport_Filter(t *testing.T) {
 	defer cleanFile()
 
 	r := NewReportPortal(nil)
-	r.Filter = &MockFilterService{
-		GetFilterM: func(project string, id int) (*Filter, error) {
+	r.Filter = &MockService{
+		GetM: func(project string, id int) (Object, error) {
 			testEqual(t, project, "test_project")
 			testEqual(t, id, 3)
 			return &Filter{
@@ -166,10 +167,10 @@ widgets: []
 	file, cleanFile := writeTmpFile(t, "dashboard", input)
 	defer cleanFile()
 
-	mockDashboard := &MockDashboardService{
-		CreateDashboardM: func(project string, d *Dashboard) error {
+	mockDashboard := &MockService{
+		CreateM: func(project string, o Object) error {
 			testEqual(t, project, "test_project")
-			testDeepEqual(t, d, &Dashboard{
+			testDeepEqual(t, o.(*Dashboard), &Dashboard{
 				Kind:        DashboardKind,
 				Name:        "MK E2E Tests Overview",
 				Description: "",
@@ -187,7 +188,7 @@ widgets: []
 		t.Errorf("Create retunred error: %s", err)
 	}
 
-	testDeepEqual(t, mockDashboard.Counter, MockDashboardServiceCounter{CreateDashboard: 1})
+	testDeepEqual(t, mockDashboard.Counter, MockServiceCounter{Create: 1})
 }
 
 func TestCreate_Filter(t *testing.T) {
@@ -210,10 +211,10 @@ orders:
 	file, cleanFile := writeTmpFile(t, "filter", input)
 	defer cleanFile()
 
-	mockFilter := &MockFilterService{
-		CreateFilterM: func(project string, d *Filter) error {
+	mockFilter := &MockService{
+		CreateM: func(project string, o Object) error {
 			testEqual(t, project, "test_project")
-			testDeepEqual(t, d, &Filter{
+			testDeepEqual(t, o.(*Filter), &Filter{
 				Kind:        FilterKind,
 				Name:        "mk-e2e-test-suite",
 				Type:        "Launch",
@@ -238,91 +239,126 @@ orders:
 		t.Errorf("Create retunred error: %s", err)
 	}
 
-	testDeepEqual(t, mockFilter.Counter, MockFilterServiceCounter{CreateFilter: 1})
+	testDeepEqual(t, mockFilter.Counter, MockServiceCounter{Create: 1})
 }
 
-func TestApply_Dashboard(t *testing.T) {
+func TestApply_Skip(t *testing.T) {
 
 	input := `kind: Dashboard
 name: MK E2E Tests Overview
-description: ""
-widgets: []
+description: Test desc
 `
 
 	file, cleanFile := writeTmpFile(t, "dashboard", input)
 	defer cleanFile()
 
-	mockDashboard := &MockDashboardService{
-		ApplyDashboardM: func(project string, d *Dashboard) error {
+	mockService := &MockService{
+		GetByNameM: func(project, name string) (Object, error) {
 			testEqual(t, project, "test_project")
-			testDeepEqual(t, d, &Dashboard{
+			testEqual(t, name, "MK E2E Tests Overview")
+
+			return &Dashboard{
 				Kind:        DashboardKind,
 				Name:        "MK E2E Tests Overview",
-				Description: "",
-				Widgets:     []*Widget{},
-			}, cmp.AllowUnexported(Dashboard{}))
-			return nil
+				Description: "Test desc",
+			}, nil
 		},
 	}
 
 	r := NewReportPortal(nil)
-	r.Dashboard = mockDashboard
+	r.Dashboard = mockService
 
 	err := r.Apply("test_project", file)
 	if err != nil {
 		t.Errorf("Apply retunred error: %s", err)
 	}
 
-	testDeepEqual(t, mockDashboard.Counter, MockDashboardServiceCounter{ApplyDashboard: 1})
+	testDeepEqual(t, mockService.Counter, MockServiceCounter{GetByName: 1})
 }
 
-func TestApply_Filter(t *testing.T) {
+func TestApply_Update(t *testing.T) {
 
-	input := `kind: Filter
-name: mk-e2e-test-suite
-type: Launch
-description: ""
-conditions:
-- filteringfield: name
-  condition: eq
-  value: mk-e2e-test-suite
-orders:
-- sortingcolumn: startTime
-  isasc: false
-- sortingcolumn: number
-  isasc: false
+	input := `kind: Dashboard
+name: MK E2E Tests Overview
+description: Test new desc
 `
 
-	file, cleanFile := writeTmpFile(t, "filter", input)
+	file, cleanFile := writeTmpFile(t, "dashboard", input)
 	defer cleanFile()
 
-	mockFilter := &MockFilterService{
-		ApplyFilterM: func(project string, d *Filter) error {
+	mockService := &MockService{
+		GetByNameM: func(project, name string) (Object, error) {
 			testEqual(t, project, "test_project")
-			testDeepEqual(t, d, &Filter{
-				Kind:        FilterKind,
-				Name:        "mk-e2e-test-suite",
-				Type:        "Launch",
-				Description: "",
-				Conditions: []FilterCondition{
-					{FilteringField: "name", Condition: "eq", Value: "mk-e2e-test-suite"},
-				},
-				Orders: []FilterOrder{
-					{SortingColumn: "startTime", IsAsc: false},
-					{SortingColumn: "number", IsAsc: false},
-				},
-			}, cmp.AllowUnexported(Filter{}))
+			testEqual(t, name, "MK E2E Tests Overview")
+
+			return &Dashboard{
+				Kind:        DashboardKind,
+				Name:        "MK E2E Tests Overview",
+				Description: "Test old desc",
+			}, nil
+		},
+		UpdateM: func(project string, current, target Object) error {
+			testEqual(t, project, "test_project")
+			testDeepEqual(t, current, &Dashboard{
+				Kind:        DashboardKind,
+				Name:        "MK E2E Tests Overview",
+				Description: "Test old desc",
+			}, cmpopts.IgnoreUnexported(Dashboard{}))
+
+			testDeepEqual(t, target, &Dashboard{
+				Kind:        DashboardKind,
+				Name:        "MK E2E Tests Overview",
+				Description: "Test new desc",
+			}, cmpopts.IgnoreUnexported(Dashboard{}))
 			return nil
 		},
 	}
 
 	r := NewReportPortal(nil)
-	r.Filter = mockFilter
+	r.Dashboard = mockService
 
 	err := r.Apply("test_project", file)
 	if err != nil {
 		t.Errorf("Apply retunred error: %s", err)
 	}
 
-	testDeepEqual(t, mockFilter.Counter, MockFilterServiceCounter{ApplyFilter: 1})
+	testDeepEqual(t, mockService.Counter, MockServiceCounter{GetByName: 1, Update: 1})
+}
+
+func TestApply_Create(t *testing.T) {
+
+	input := `kind: Dashboard
+name: MK E2E Tests Overview
+description: Test desc
+`
+
+	file, cleanFile := writeTmpFile(t, "dashboard", input)
+	defer cleanFile()
+
+	mockService := &MockService{
+		GetByNameM: func(project, name string) (Object, error) {
+			testEqual(t, project, "test_project")
+			testEqual(t, name, "MK E2E Tests Overview")
+			return nil, nil
+		},
+		CreateM: func(project string, o Object) error {
+			testEqual(t, project, "test_project")
+			testDeepEqual(t, o, &Dashboard{
+				Kind:        DashboardKind,
+				Name:        "MK E2E Tests Overview",
+				Description: "Test desc",
+			}, cmpopts.IgnoreUnexported(Dashboard{}))
+			return nil
+		},
+	}
+
+	r := NewReportPortal(nil)
+	r.Dashboard = mockService
+
+	err := r.Apply("test_project", file)
+	if err != nil {
+		t.Errorf("Apply retunred error: %s", err)
+	}
+
+	testDeepEqual(t, mockService.Counter, MockServiceCounter{GetByName: 1, Create: 1})
 }


### PR DESCRIPTION
the Apply method is now idependent from the service kind
and can be used in the feature for new services