### PR TITLE
chore: add export by name option

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -14,10 +14,12 @@ type Test struct {
 }
 
 var (
-	exportFile        string
-	exportProject     string
-	exportDashboardID int
-	exportFilterID    int
+	exportFile          string
+	exportProject       string
+	exportDashboardID   int
+	exportDashboardName string
+	exportFilterID      int
+	exportFilterName    string
 
 	exportCmd = &cobra.Command{
 		Use: "export",
@@ -39,7 +41,7 @@ var (
 			}
 			r := rpdac.NewReportPortal(c)
 
-			return r.Export(rpdac.DashboardKind, exportProject, exportDashboardID, exportFile)
+			return r.Export(rpdac.DashboardKind, exportProject, exportDashboardID, exportDashboardName, exportFile)
 		},
 	}
 
@@ -54,7 +56,7 @@ var (
 			}
 			r := rpdac.NewReportPortal(c)
 
-			return r.Export(rpdac.DashboardKind, exportProject, exportFilterID, exportFile)
+			return r.Export(rpdac.DashboardKind, exportProject, exportFilterID, exportFilterName, exportFile)
 		},
 	}
 )
@@ -81,14 +83,14 @@ func init() {
 
 	// Export Dashboard CMD
 	exportDashboardCmd.Flags().IntVar(&exportDashboardID, "id", -1, "ReportPortal Dashboard ID")
-	exportDashboardCmd.MarkFlagRequired("id")
+	exportDashboardCmd.Flags().StringVar(&exportDashboardName, "name", "", "ReportPortal Dashboard Name")
 	decorateCommonOptions(exportDashboardCmd)
 
 	exportCmd.AddCommand(exportDashboardCmd)
 
 	// Export Filter CMD
 	exportFilterCmd.Flags().IntVar(&exportFilterID, "id", -1, "ReportPortal Filter ID")
-	exportFilterCmd.MarkFlagRequired("id")
+	exportFilterCmd.Flags().StringVar(&exportFilterName, "name", "", "ReportPortal Filter Name")
 	decorateCommonOptions(exportFilterCmd)
 
 	exportCmd.AddCommand(exportFilterCmd)

--- a/pkg/rpdac/reportportal_test.go
+++ b/pkg/rpdac/reportportal_test.go
@@ -95,7 +95,40 @@ func TestExport_Dashboard(t *testing.T) {
 		},
 	}
 
-	err := r.Export(DashboardKind, "test_project", 3, file)
+	err := r.Export(DashboardKind, "test_project", 3, "", file)
+	if err != nil {
+		t.Errorf("Export returned error: %s", err)
+	}
+
+	want := `kind: Dashboard
+name: MK E2E Tests Overview
+description: ""
+widgets: []
+`
+
+	testFileContains(t, file, want)
+}
+
+func TestExport_DashboardByName(t *testing.T) {
+	file, cleanFile := tmpFile(t, "dashboard")
+	defer cleanFile()
+
+	r := NewReportPortal(nil)
+
+	r.Dashboard = &MockService{
+		GetByNameM: func(project string, name string) (Object, error) {
+			testEqual(t, project, "test_project")
+			testEqual(t, name, "MK E2E Tests Overview")
+			return &Dashboard{
+				Kind:        DashboardKind,
+				Name:        "MK E2E Tests Overview",
+				Description: "",
+				Widgets:     []*Widget{},
+			}, nil
+		},
+	}
+
+	err := r.Export(DashboardKind, "test_project", -1, "MK E2E Tests Overview", file)
 	if err != nil {
 		t.Errorf("Export returned error: %s", err)
 	}
@@ -134,7 +167,7 @@ func TestExport_Filter(t *testing.T) {
 		},
 	}
 
-	err := r.Export(FilterKind, "test_project", 3, file)
+	err := r.Export(FilterKind, "test_project", 3, "", file)
 	if err != nil {
 		t.Errorf("Export returned error: %s", err)
 	}


### PR DESCRIPTION
Dashboards and filters can now be exported by name using the --name
option